### PR TITLE
Pass props to component

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,21 @@ const App = ({ user }) => (
 #### With code splitting
 
 You're not logged in ? `<Login />` component is the only loaded, `<Home />` will be loaded when the user will be logged in.
+
+Use componentProps to pass props to lazy loaded component.
+
 ```jsx
 import Async from 'react-code-splitting'
 
 import Login from './Login'
 const Home = () => <Async load={import('./Home')} />
+const LostPassword = (props) => <Async load={import('./LostPassword')} componentProps={props}/>
 
 const App = ({ user }) => (
   <Body>
     {user.loggedIn ? <Route path="/" component={Home} /> : <Redirect to="/login" />}
     <Route path="/login" component={Login} />
+    <Route path="/lostpassword" component={LostPassword} />
   </Body>
 )
 ```

--- a/dist/react-code-splitting.js
+++ b/dist/react-code-splitting.js
@@ -36,7 +36,9 @@ var Async = function (_React$Component) {
         _this.C = c;_this.forceUpdate();
       });
     }, _this.render = function () {
-      return _this.C ? _react2.default.createElement(_this2.C.default, null) : null;
+      var componentProps = _this.props.componentProps;
+
+      return _this.C ? _react2.default.createElement(_this2.C.default, componentProps) : null;
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,10 @@ export default class Async extends React.Component {
     this.props.load.then((c) => { this.C = c; this.forceUpdate() })
   }
 
-  render = () => this.C ? <this.C.default /> : null
+  render = () => {
+    const {componentProps} = this.props
+    return this.C ? <this.C.default {...componentProps} /> : null
+  }
 }
 
 Async.propTypes = {


### PR DESCRIPTION
Async can pass componentProps to the lazy loaded component. For instance if you need the react router params in props. 