### PR TITLE
Handle loading components in the background

### DIFF
--- a/dist/react-code-splitting.js
+++ b/dist/react-code-splitting.js
@@ -37,8 +37,13 @@ var Async = function (_React$Component) {
 
     return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Async.__proto__ || Object.getPrototypeOf(Async)).call.apply(_ref, [this].concat(args))), _this), _this.componentWillMount = function () {
       _this.props.load.then(function (c) {
-        _this.C = c;_this.forceUpdate();
+        _this.C = c;
+        if (!_this.cancelUpdate) {
+          _this.forceUpdate();
+        }
       });
+    }, _this.componentWillUnmount = function () {
+      _this.cancelUpdate = true;
     }, _this.render = function () {
       var componentProps = _this.props.componentProps;
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,16 @@ import PropTypes from 'prop-types'
 
 export default class Async extends React.Component {
   componentWillMount = () => {
-    this.props.load.then((c) => { this.C = c; this.forceUpdate() })
+    this.props.load.then((c) => { 
+      this.C = c
+      if (!this.cancelUpdate) {
+        this.forceUpdate()
+      }
+    })
+  }
+
+  componentWillUnmount = () => {
+    this.cancelUpdate = true
   }
 
   render = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 
 export default class Async extends React.Component {
   componentWillMount = () => {
+    this.cancelUpdate = false
     this.props.load.then((c) => { 
       this.C = c
       if (!this.cancelUpdate) {


### PR DESCRIPTION
I've been getting warnings about calling `forceUpdate` whenever I'm loading components in the background or if I navigate away from a component before it finishes loading.

```
Warning: forceUpdate(...): Can only update a mounted or mounting component. This usually means you called forceUpdate() on an unmounted component. This is a no-op. Please check the code for the Async component.
```

This adds a flag which will prevent `forceUpdate` from being called if the component finishes loading after it's already been unmounted.

It also handles the case where the user navigates away and back to the component before it finishes loading.